### PR TITLE
change testrunner from ava to jest

### DIFF
--- a/__tests__/.babelrc
+++ b/__tests__/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["transform-async-to-generator"]
+}

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -1,0 +1,8 @@
+const m = require('../index');
+
+it('retrieve some results from the api', done => {
+  m.execute('node').then(results => {
+    expect(results.items.length > 0).toBeTruthy();
+    done();
+  });
+});

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -1,8 +1,6 @@
 const m = require('../index');
 
-it('retrieve some results from the api', done => {
-  m.execute('node').then(results => {
-    expect(results.items.length > 0).toBeTruthy();
-    done();
-  });
+it('retrieve some results from the api', async () => {
+  const results = await m.execute('node');
+  expect(results.items.length > 0).toBeTruthy();
 });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "got": "^6.3.0"
   },
   "devDependencies": {
+    "babel-core": "^6.17.0",
+    "babel-jest": "^16.0.0",
+    "babel-plugin-transform-async-to-generator": "^6.16.0",
+    "babel-polyfill": "^6.16.0",
+    "babel-preset-es2015": "^6.16.0",
     "jest": "^15.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "ava"
+    "test": "jest"
   },
   "author": "Vu Tran <vu@vu-tran.com>",
   "license": "MIT",
@@ -20,6 +20,6 @@
     "got": "^6.3.0"
   },
   "devDependencies": {
-    "ava": "^0.16.0"
+    "jest": "^15.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,0 @@
-import test from 'ava';
-import m from '.';
-
-test('retrieve some results from the api', async t => {
-  const results = await m.execute('node');
-  t.true(results.items.length > 0);
-});


### PR DESCRIPTION
fixes issue #1 
- why not async/await? it would need babel-integration with babel-plugin-transform-async-to-generator - which would be a overhead just for testing
-  because of this, there is also no import available
